### PR TITLE
Correction in fst and snd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.DS_Store
+docs/build

--- a/README.md
+++ b/README.md
@@ -2,3 +2,18 @@
 
 Scilla short for Smart Contract Intermediate-Level LAnguage is a smart contract
 language being developed for Zilliqa. 
+
+
+## Contributing
+
+If you spot any issues or have any ideas on how we can improve the documentation, help us log an issue [here](https://github.com/Zilliqa/scilla-docs/issues)
+
+### Before submitting a pull request
+
+Please preview your HTML files BEFORE submitting a pull request. Try your best to [squash](https://blog.github.com/2016-04-01-squash-your-commits/) your commits before making the pull request. We know it's difficult, but it helps us keep our commit logs clean and makes the reviewers' lives easier.
+
+To preview:
+1. You need to have [sphinx](http://www.sphinx-doc.org/en/master/) installed. Install Sphinx by running `pip install -U Sphinx`.
+2. Run `make html` from `docs` folder and make sure that the edits are rendered correctly on the HTML file
+
+

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -126,7 +126,6 @@ the first transition ``setHello (msg :  String)`` to set ``welcome_msg`` is
 given below: 
 
 
-
 .. code-block:: ocaml
     :linenos:
 
@@ -314,28 +313,32 @@ At this stage, our contract fragment will have the following form:
 Final Touches
 *********************
 
-We may now add the second transition ``getHello()`` that allows any caller to be greeted by ``welcome_msg``. The declaration is similar to ``setHello (msg : String)`` accept that ``getHello()`` does not take any parameter. 
+We may now add the second transition ``getHello()`` that allows client applications to know what the ``welcome_msg`` is. The declaration is similar to ``setHello (msg : String)`` except that ``getHello()`` does not take any parameter.
 
+In Scilla, there are two ways that transitions can transmit data. One way is through ``send`` messages (covered in ``setHello``), and another way is through events. The difference between the two lies in what you are trying to communicate to.
 
+``send`` is used to send message to another smart contract and is not emitted back to your client application. Meanwhile, events are dispatched signals that smart contracts can use to transmit data to client applications. 
 
 .. code-block:: ocaml
 
     transition getHello ()
         r <- welcome_msg;
-        msg = {_tag : Main; _recipient : _sender; _amount : 0; msg : r};
-        msgs = one_msg msg;
-        send msgs
+        e = {_eventname: "GetHello"; msg: r};
+        event e
     end
 
 .. note::
 	Reading from a mutable variable is done via the operator ``<-``. In our example, this translates to ``r <- welcome_msg``.
+
+In the ``getHello()`` transition, we will first read from a mutable variable, then we construct an event message. Take note that ``_eventname`` is a compulsory variable which must be added into an event message. You are free to name it whatever you want, but it is a good practice to give it a unique name so you know where your events are being emitted from. 
+
+After constructing the event message, you can emit the event to your client application through ``event e``.
 
 The complete contract that implements the desired specification is given below:
 
 .. code-block:: ocaml
 
     (* HelloWorld contract *)
-
 
     (***************************************************)
     (*               Associated library                *)
@@ -376,9 +379,8 @@ The complete contract that implements the desired specification is given below:
 
     transition getHello ()
         r <- welcome_msg;
-        msg = {_tag : Main; _recipient : _sender; _amount : 0; msg : r};
-        msgs = one_msg msg;
-        send msgs
+        e = {_eventname: "getHello"; msg: r};
+        event e
     end
 
 

--- a/docs/source/scilla-in-depth.rst
+++ b/docs/source/scilla-in-depth.rst
@@ -604,9 +604,8 @@ to a mutable field ``pp``:
                 Pair {(String) (Uint32)} s1 num
     ...
 
-Note the difference in how we perform a type declaration ``Pair{ (A') (B')}`` 
-and the syntax used to create a pair of values using the constructor ``Pair (A') (B')``.
-In the type declaration, a pair of curly braces surounds the two data types ``A'`` and ``B'``.
+Note the difference in how we perform a type declaration ``Pair( (A') (B'))`` 
+and the syntax used to create a pair of values using the constructor ``Pair { (A') (B') }``.
 
 We now illustrate how pattern matching can be used to extract the
 first element from a ``Pair``. The function ``fst`` shown below
@@ -616,14 +615,14 @@ is defined in the ``PairUtils`` library of the Scilla standard library.
 
   let fst =
     tfun 'A =>
-    fun (p : Pair 'A 'A) =>
+    tfun 'B =>
+    fun (p : Pair 'A 'B) =>
     match p with
-    | Pair {'A 'A} a b =>
-        a
+    | Pair a b => a
     end
 
   let p = Pair {Int32 Int32} one two in
-  let fst_int = @fst Int32 in
+  let fst_int = @fst Int32 Int32 in
   let a = fst_int p in
     ... (* a = one *) ...
 

--- a/docs/source/scilla-in-depth.rst
+++ b/docs/source/scilla-in-depth.rst
@@ -442,7 +442,7 @@ has two constructors ``None`` and ``Some``.
 
         let x = 
           let ten = Int32 10 in
-          Some {Int32} 10
+          Some {Int32} ten
       
 
    + ``None`` represents the absence of any value. ``None {`A}`` constructs an


### PR DESCRIPTION
`fst` and `snd` should take in two types according to `stdlib`'s implementation.
https://github.com/Zilliqa/scilla/blob/master/src/stdlib/PairUtils.scilla