### PR TITLE
Minor corrections to design principles, and reworked examples

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ verified) compilers, concurrent and distributed applications, including
 blockchains among others.
 
 `Zilliqa` --- the underlying blockchain platform on which Scilla contracts are
-run has been  designed to be scalable. It employs the idea of sharding to
+run --- has been designed to be scalable. It employs the idea of sharding to
 validate transactions in parallel. Zilliqa has an intrinsic token named
 `Zilling`, ZIL for short that are required to run smart contracts on Zilliqa.
 
@@ -46,9 +46,6 @@ specification described in this document are subject to change. Scilla
 currently comes with an interpreter binary that has been integrated into two
 Scilla-specific web-based IDEs. :ref:`trial-label` presents the features of the
 two IDEs.  
-
-Note that Scilla does not have a type checker implemented yet and hence type
-safety of contracts written in Scilla is not guaranteed.
 
 Resources
 *********

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -35,7 +35,7 @@ possible to produce rigorous guarantees about the behavior of a contract.
 Applying formal verification tools with existing languages such as Solidity
 however is not an easy task because of the extreme expressivity typical of a
 Turing-complete language. Indeed, there is a trade-off between making a
-language simpler to understand and amenable to formal verification and making
+language simpler to understand and amenable to formal verification, and making
 it more expressive. For instance, Bitcoin's scripting language occupies the
 `simpler` end of the spectrum and does not handle stateful-objects. On the
 `expressive` side of the spectrum is a Turing-complete language such as
@@ -66,9 +66,9 @@ composition and invariants.
 Any in-contract computation happening within a transition has to terminate, and
 have a predictable effect on the state of the contract and the execution.  In
 order to achieve this, Scilla draws inspiration from functional programming
-with effects, drawing a distinction between pure expressions (e.g., expressions
+with effects in distinguishing between pure expressions (e.g., expressions
 with primitive data types and maps), impure local state manipulations (i.e.,
-reading/writing into contract fields) and blockchain reflection (e.g., reading
+reading/writing into contract fields), and blockchain reflection (e.g., reading
 current block number). By carefully designing semantics of interaction between
 pure and impure language aspects, Scilla ensures a number of foundational
 properties about contract transitions, such as progress and type preservation,

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -210,7 +210,7 @@ event gets stored on the blockchain for everyone to see.
    In our example we have chosen to name the event after the
    transition that issues the event, but any name can be
    chosen. However, it is recommended that you name the events in a
-   way makes it easy to see which part of the code issued the event.
+   way that makes it easy to see which part of the code issued the event.
 
 
 

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -13,7 +13,7 @@ following  specification:
   by the creator of the contract. The variable is immutable in the
   sense that once initialized, its value cannot be changed. ``owner``
   will be of type ``ByStr20`` (a hexadecimal Byte String representing
-  a 20 byte blockchain address).
+  a 20 byte address).
 
 + It should have a `mutable variable` ``welcome_msg`` of type ``String``
   initialized to ``""``. Mutability here refers to the possibility of modifying

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -442,10 +442,10 @@ and ``_amount``. The ``_recipient`` field is the blockchain address
 ``_amount`` field is the number of ZIL to be transferred to that
 account.
 
-The value of the ``_tag`` field is the name (of type ``String``) of the transition
-that is to be invoked on the ``_recipient` contract. If ``_recipient`` 
-is a user account, then the value of ``_tag` can be set to be ``""`` (the empty string).
-In fact, if the `_recipient` is a user account, then the value of ``_tag`` is ignored.
+The value of the ``_tag`` field is the name of the transition (of type ``String``) 
+that is to be invoked on the ``_recipient`` contract. If ``_recipient`` 
+is a user account, then the value of ``_tag`` can be set to be ``""`` (the empty string).
+In fact, if the ``_recipient`` is a user account, then the value of ``_tag`` is ignored.
 
 In addition to the compulsory fields the message may contain other
 fields, such as ``code`` above. However, if the message recipient is a

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -233,7 +233,7 @@ This is done through the following instruction:
     Writing to a mutable variable is done via the operator ``:=``.
 
 
-And as in the previous case, the contract then issues an event with
+And as in the previous case, the contract then emits an event with
 the code ``set_hello_code``.
 
 

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -134,11 +134,11 @@ given below:
       is_owner = builtin eq owner _sender;
       match is_owner with
       | False =>
-        e = {_eventname : "setHello()"; code : not_owner_code};
+        e = {_eventname : "setHello"; code : not_owner_code};
         event e
       | True =>
         welcome_msg := msg;
-        e = {_eventname : "setHello()"; code : set_hello_code};
+        e = {_eventname : "setHello"; code : set_hello_code};
         event e
       end
     end
@@ -193,7 +193,7 @@ More concretely, the output event in this case is:
 
 .. code-block:: ocaml
 
-        e = {_eventname : "setHello()"; code : not_owner_code};
+        e = {_eventname : "setHello"; code : not_owner_code};
 
 An event is comprised of a number of ``vname : value`` pairs delimited
 by ``;`` inside a pair of curly braces ``{}``. An event must contain
@@ -279,11 +279,11 @@ At this stage, our contract fragment will have the following form:
       is_owner = builtin eq owner _sender;
       match is_owner with
       | False =>
-        e = {_eventname : "setHello()"; code : not_owner_code};
+        e = {_eventname : "setHello"; code : not_owner_code};
         event e
       | True =>
         welcome_msg := msg;
-        e = {_eventname : "setHello()"; code : set_hello_code};
+        e = {_eventname : "setHello"; code : set_hello_code};
         event e
       end
     end
@@ -301,7 +301,7 @@ not take a parameter.
 
     transition getHello ()
         r <- welcome_msg;
-        e = {_eventname: "GetHello"; msg: r};
+        e = {_eventname: "getHello"; msg: r};
         event e
     end
 

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -442,10 +442,10 @@ and ``_amount``. The ``_recipient`` field is the blockchain address
 ``_amount`` field is the number of ZIL to be transferred to that
 account.
 
-The ``_tag`` field is only used when the value of the ``_recipient``
-field is the address of a contract. In this case, the value of
-the ``_tag`` field is the name (of type ``String``) of the transition
-that is to be invoked on the recipient contract.
+The value of the ``_tag`` field is the name (of type ``String``) of the transition
+that is to be invoked on the ``_recipient` contract. If ``_recipient`` 
+is a user account, then the value of ``_tag` can be set to be ``""`` (the empty string).
+In fact, if the `_recipient` is a user account, then the value of ``_tag`` is ignored.
 
 In addition to the compulsory fields the message may contain other
 fields, such as ``code`` above. However, if the message recipient is a

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -9,10 +9,11 @@ We start off by writing a classical ``HelloWorld.scilla`` contract with the
 following  specification:
 
 
-+ It should have an `immutable variable` ``owner`` to be initialized by the
-  creator of the contract. The variable is immutable in the sense that once
-  initialized, its value cannot be changed. ``owner`` will be of type
-  ``ByStr20`` (a hexadecimal Byte String representing 20 bytes). 
++ It should have an `immutable variable` ``owner`` to be initialized
+  by the creator of the contract. The variable is immutable in the
+  sense that once initialized, its value cannot be changed. ``owner``
+  will be of type ``ByStr20`` (a hexadecimal Byte String representing
+  a 20 byte blockchain address).
 
 + It should have a `mutable variable` ``welcome_msg`` of type ``String``
   initialized to ``""``. Mutability here refers to the possibility of modifying
@@ -27,7 +28,7 @@ following  specification:
   ``welcome_msg``. ``getHello`` will not take any input. 
 
 
-Defining Contract and its (Im)Mutable Variables
+Defining contract and its (im)mutable variables
 **************************************************
 
 A contract is declared using the ``contract`` keyword that starts the scope of
@@ -94,7 +95,7 @@ that includes the contract name and its (im)mutable variables:
 
 
 
-Defining Interfaces `aka` Transitions
+Defining interfaces `aka` transitions
 ***************************************
 
 Interfaces like ``setHello`` are referred to as `transitions` in Scilla.
@@ -106,7 +107,7 @@ Transitions are similar to `functions` or `methods` in other languages.
 	which follows a communicating automaton. A contract in Scilla is an
 	automaton with some state. The state of an automaton can be changed via a
 	transition that takes a previous state and an input and yields a new state.
-	Check `wikipedia entry <https://en.wikipedia.org/wiki/Transition_system>`_
+	Check the `wikipedia entry <https://en.wikipedia.org/wiki/Transition_system>`_
 	to read more about transition systems.
 
 A transition is declared using the keyword ``transition``. The end of a
@@ -133,14 +134,12 @@ given below:
       is_owner = builtin eq owner _sender;
       match is_owner with
       | False =>
-        msg = {_tag : "Main"; _recipient : _sender; _amount : Uint128 0; code : not_owner_code};
-        msgs = one_msg msg;
-        send msgs
+        e = {_eventname : "setHello()"; code : not_owner_code};
+        event e
       | True =>
         welcome_msg := msg;
-        msg = {_tag : "Main"; _recipient : _sender; _amount : Uint128 0; code : set_hello_code};
-        msgs = one_msg msg;
-        send msgs
+        e = {_eventname : "setHello()"; code : set_hello_code};
+        event e
       end
     end
 
@@ -162,67 +161,66 @@ below.
 
 .. code-block:: ocaml
 
-	match expr with
-	| x => expr_1
-	| y => expr_2
-        end 
+                match expr with
+                | pattern_1 => expr_1
+                | pattern_2 => expr_2
+                end 
 
-The above code checks whether ``expr`` evaluates to ``x`` or ``y``. If ``expr``
-evaluates to ``x``, then the next expression to be evaluated will be
-``expr_1``, else if it evaluates to ``y``, then, the next expression to be
-evaluated will be ``expr_2``. Simply put, the above code implements an
-``if-then-else`` instruction. 
+The above code checks whether ``expr`` evaluates to a value that
+matches ``pattern_1`` or ``pattern_2``. If ``expr`` evaluates to a
+value matching ``pattern_1``, then the next expression to be evaluated
+will be ``expr_1``.  Otherwise, if ``expr`` evaluates to a value
+matching ``pattern_2``, then the next expression to be evaluated will
+be ``expr_2``.
+
+Hence, the following code block implements an ``if-then-else`` instruction:
+
+.. code-block:: ocaml
+
+                match expr with
+                | True  => expr_1
+                | False => expr_2
+                end
+
   
-Caller is not owner
-""""""""""""""""""""""""
+The caller is not the owner
+"""""""""""""""""""""""""""""
 
-In case the caller is different from ``owner``, the transition takes the
-``False`` branch and the contract sends out a message. Scilla defines a special
-type ``Message`` for outgoing messages. An outgoing message contains
-information about any other contract that needs to be called as a part of the
-current call. 
+In case the caller is different from ``owner``, the transition takes
+the ``False`` branch and the contract issues an event using the instruction ``event``. 
 
-The output message in this case is an error code ``not_owner_code`` included in
-``msg``.  More concretely, the output message in this case is:
+More concretely, the output event in this case is:
 
 .. code-block:: ocaml
 
-        msg = {_tag : "Main"; _recipient : _sender; _amount : Uint128 0; code : not_owner_code};
+        e = {_eventname : "setHello()"; code : not_owner_code};
+
+An event is comprised of a number of ``vname : value`` pairs delimited
+by ``;`` inside a pair of curly braces ``{}``. An event must contain
+the compulsory field ``_eventname``, and may contain other fields such
+as the ``code`` field in the example above. The fields may occur in
+any order, though two events with the same name must contain the same
+fields of the same respective types.
+
+Once an event has been issued (using the instruction ``event e``), the
+event gets stored on the blockchain for everyone to see.
+
+.. note::
+
+   In our example we have chosen to name the event after the
+   transition that issues the event, but any name can be
+   chosen. However, it is recommended that you name the events in a
+   way makes it easy to see which part of the code issued the event.
 
 
-        
-An outgoing message is formed of  ``vname : value`` pairs delimited by ``;``,
-the scope of which is defined by ``{}``. Each outgoing message must have
-three compulsory fields: ``_tag``, ``_recipient`` and ``_amount`` in no
-particular order. ``_recipient`` is an account address to which the message
-will be sent. ``_tag`` is the name of the transition to be invoked in
-``_recipient`` and ``_amount`` is the number of ZIL to be transferred to
-``_recipient``. 
-
-Apart from these compulsory fields, a message may have other fields. In the
-current example, the message has a field ``code`` to report an error message.
 
 
-Sending a message out is done using the ``send`` instruction that takes a list
-of entries of type ``Message``. In the current example, the list will contain
-only one entry.  To sum up, the following code will create a message and send
-it out.
-
-.. code-block:: ocaml
-
-        msgs = one_msg msg;
-        send msgs
-
-``one_msg`` is a utility function that allows to create a list of messages and
-inserts ``msg`` into the list.
-
-
-Caller is owner
+The caller is the owner
 """"""""""""""""""""""""
 
 In case the caller is ``owner``, the contract allows the caller to set the
 value of the mutable variable ``welcome_msg`` to the input parameter ``msg``.
-It is done through the following instruction. 
+This is done through the following instruction:
 
 
 .. code-block:: ocaml
@@ -232,48 +230,35 @@ It is done through the following instruction.
 
 .. note::
  
-    Writing to a mutable parameter is done via the operator ``:=``.
+    Writing to a mutable variable is done via the operator ``:=``.
 
 
-
-And as in the previous case, the contract then sends out a message to the caller
-with the code ``set_hello_code``. 
+And as in the previous case, the contract then issues an event with
+the code ``set_hello_code``.
 
 
 Libraries 
 ***************
 
-A Scilla contract may come with some helper libraries that declare purely
-functional (with no state manipulation) components of a contract. A library is
-declared in the preamble of a contract using the keyword ``library`` followed by
-the name of the library. In our current example a library declaration would
-look like the following:
+A Scilla contract may come with some helper libraries that declare
+purely functional components of a contract, i.e., components with no
+state manipulation. A library is declared in the preamble of a
+contract using the keyword ``library`` followed by the name of the
+library. In our current example a library declaration would look as
+follows:
 
-
- 
 .. code-block:: ocaml
 
 	library HelloWorld
 
-In our example, the library will include the definition of the error codes as
-given below defined using standard ``let x = y in expr`` construct. 
+The library may include utility functions and program constants using
+the ``let x = y in expr`` construct. In our example the library will
+only include the definition of error codes:
 
 .. code-block:: ocaml
 
 	let not_owner_code  = Uint32 1
 	let set_hello_code  = Uint32 2
-
-The library may also include utility functions, for instance, the function
-``one_msg`` that creates a list with one entry of type ``Message`` as given
-below:
-
-.. code-block:: ocaml
-
-	let one_msg =
-  	   fun (msg : Message) =>
-           let nil_msg = Nil {Message} in
-           Cons {Message} msg nil_msg
-
 
 At this stage, our contract fragment will have the following form:
 
@@ -281,11 +266,6 @@ At this stage, our contract fragment will have the following form:
 	
    library HelloWorld
   
-    let one_msg =
-        fun (msg : Message) =>
-        let nil_msg = Nil {Message} in
-        Cons {Message} msg nil_msg
-
     let not_owner_code  = Uint32 1
     let set_hello_code  = Uint32 2
 
@@ -299,25 +279,23 @@ At this stage, our contract fragment will have the following form:
       is_owner = builtin eq owner _sender;
       match is_owner with
       | False =>
-        msg = {_tag : "Main"; _recipient : _sender; _amount : Uint128 0; code : not_owner_code};
-        msgs = one_msg msg;
-        send msgs
+        e = {_eventname : "setHello()"; code : not_owner_code};
+        event e
       | True =>
         welcome_msg := msg;
-        msg = {_tag : "Main"; _recipient : _sender; _amount : Uint128 0; code : set_hello_code};
-        msgs = one_msg msg;
-        send msgs
+        e = {_eventname : "setHello()"; code : set_hello_code};
+        event e
       end
     end
 
-Final Touches
+
+The second transition
 *********************
 
-We may now add the second transition ``getHello()`` that allows client applications to know what the ``welcome_msg`` is. The declaration is similar to ``setHello (msg : String)`` except that ``getHello()`` does not take any parameter.
-
-In Scilla, there are two ways that transitions can transmit data. One way is through ``send`` messages (covered in ``setHello``), and another way is through events. The difference between the two lies in what you are trying to communicate to.
-
-``send`` is used to send message to another smart contract and is not emitted back to your client application. Meanwhile, events are dispatched signals that smart contracts can use to transmit data to client applications. 
+We may now add the second transition ``getHello()`` that allows client
+applications to know what the ``welcome_msg`` is. The declaration is
+similar to ``setHello (msg : String)`` except that ``getHello()`` does
+not take a parameter.
 
 .. code-block:: ocaml
 
@@ -328,13 +306,38 @@ In Scilla, there are two ways that transitions can transmit data. One way is thr
     end
 
 .. note::
-	Reading from a mutable variable is done via the operator ``<-``. In our example, this translates to ``r <- welcome_msg``.
+	Reading from a mutable variable is done via the operator ``<-``.
 
-In the ``getHello()`` transition, we will first read from a mutable variable, then we construct an event message. Take note that ``_eventname`` is a compulsory variable which must be added into an event message. You are free to name it whatever you want, but it is a good practice to give it a unique name so you know where your events are being emitted from. 
+In the ``getHello()`` transition, we will first read from a mutable
+variable, and then we construct and issue the event.
 
-After constructing the event message, you can emit the event to your client application through ``event e``.
 
-The complete contract that implements the desired specification is given below:
+Scilla version
+***************
+
+Once a contract has been deployed on the network, it cannot be
+changed. It is therefore necessary to specify which version of Scilla
+the contract is written in, so as to ensure that the behaviour of the
+contract does not change even if changes are made to the Scilla
+specification.
+
+The Scilla version of the contract is declared using the keyword
+``scilla_version``:
+
+.. code-block:: ocaml
+
+    scilla_version 1
+
+The version declaration must appear before any library or contract
+code.
+
+
+Putting it all together
+*************************
+
+The complete contract that implements the desired specification is
+given below, where we have added comments using the ``(* *)``
+construct:
 
 .. code-block:: ocaml
 
@@ -350,11 +353,6 @@ The complete contract that implements the desired specification is given below:
     (*               Associated library                *)
     (***************************************************)
     library HelloWorld
-
-    let one_msg = 
-      fun (msg : Message) => 
-      let nil_msg = Nil {Message} in
-      Cons {Message} msg nil_msg
 
     let not_owner_code  = Uint32 1
     let set_hello_code  = Uint32 2
@@ -372,45 +370,44 @@ The complete contract that implements the desired specification is given below:
       is_owner = builtin eq owner _sender;
       match is_owner with
       | False =>
-        msg = {_tag : "Main"; _recipient : _sender; _amount : 0; code : not_owner_code};
-        msgs = one_msg msg;
-        send msgs
+        e = {_eventname : "setHello()"; code : not_owner_code};
+        event e
       | True =>
         welcome_msg := msg;
-        msg = {_tag : "Main"; _recipient : _sender; _amount : 0; code : set_hello_code};
-        msgs = one_msg msg;
-        send msgs
+        e = {_eventname : "setHello()"; code : set_hello_code};
+        event e
       end
     end
 
     transition getHello ()
-        r <- welcome_msg;
-        e = {_eventname: "getHello"; msg: r};
-        event e
+      r <- welcome_msg;
+      e = {_eventname: "getHello"; msg: r};
+      event e
     end
 
 
 
-Crowdfunding
-###################
+A second example: Crowdfunding
+#################################
 
 In this section, we present a slightly more involved contract that runs a
 crowdfunding campaign. In a crowdfunding campaign, a project owner wishes to
 raise funds through donations from the community. 
 
-It is  assumed that the owner (``owner``) wishes to run the campaign for a
-certain pre-determined period of time (``max_block``). The owner also wishes to
-raise a minimum amount of funds (``goal``) without which the project can not be
+It is assumed that the owner (``owner``) wishes to run the campaign
+until a certain, pre-determined block number is reached on the
+blockchain (``max_block``). The owner also wishes to raise a minimum
+amount of funds (``goal``) without which the project can not be
 started. The contract hence has three immutable variables ``owner``,
-``max_block`` and ``goal``. 
+``max_block`` and ``goal``.
 
 
-The campaign is deemed successful if the owner can raise the minimum goal in the
-stipulated time. In
-case the campaign is unsuccessful, the donations are returned to the project
-backers who contributed during the campaign. The contract maintains two mutable
-variables: ``backer`` a map between contributor's address and amount
-contributed and a boolean flag ``funded`` that indicates whether the owner has already
+The campaign is deemed successful if the owner can raise the goal in
+the stipulated time. In case the campaign is unsuccessful, the
+donations are returned to the project backers who contributed during
+the campaign. The contract maintains two mutable variables: ``backer``
+a map between contributor's address and amount contributed and a
+boolean flag ``funded`` that indicates whether the owner has already
 transferred the funds after the end of the campaign.
 
 The contract contains three transitions: ``Donate ()`` that allows anyone to
@@ -419,7 +416,77 @@ owner** to claim the donated amount and transfer it to ``owner`` and
 ``ClaimBack()`` that allows contributors to claim back their donations in case
 the campaign is not successful.
 
-The complete contract is given below:
+
+Sending messages
+**********************
+
+In Scilla, there are two ways that transitions can transmit data. One
+way is through events, as covered in the previous example. The other
+is through the sending of messages using the instruction ``send``.
+
+``send`` is used to send messages to other accounts, either in order
+to invoke transitions on another smart contract, or to transfer money
+to user accounts. On the other hand, events are dispatched signals
+that smart contracts can use to transmit data to client applications.
+
+To construct a message we use a similar syntax as when constructing
+events:
+
+.. code-block:: ocaml
+
+   msg = {_tag : ""; _recipient : owner; _amount : bal; code : got_funds_code};
+
+A message must contain the compulsory fields ``_tag``, ``_recipient``
+and ``_amount``. The ``_recipient`` field is the blockchain address
+(of type ``ByStr20``) that the message is to be sent to, and the
+``_amount`` field is the number of ZIL to be transferred to that
+account.
+
+The ``_tag`` field is only used when the value of the ``_recipient``
+field is the address of a contract. In this case, the value of
+the ``_tag`` field is the name (of type ``String``) of the transition
+that is to be invoked on the recipient contract.
+
+In addition to the compulsory fields the message may contain other
+fields, such as ``code`` above. However, if the message recipient is a
+contract, the additional fields must have the same names and types as
+the parameters of the transition being invoked on the recipient
+contract.
+
+Sending a message is done using the ``send`` instruction, which takes
+a list of messages as a parameter. Since we will only ever send one
+message at a time in the crowdfunding contract, we define a library
+function ``one_msg`` to construct a list consisting of one message:
+
+.. code-block:: ocaml
+                
+   let one_msg =
+     fun (msg : Message) =>
+     let nil_msg = Nil {Message} in
+       Cons {Message} msg nil_msg
+
+
+To send out a message, we first construct the message, insert it into
+a list, and send it:
+
+.. code-block:: ocaml
+
+   msg = {_tag : ""; _recipient : owner; _amount : bal; code : got_funds_code};
+   msgs = one_msg msg;
+   send msgs
+
+
+.. note::
+
+   The Zilliqa blockchain does not yet support sending multiple
+   messages in the same ``send`` instruction. The list given as an
+   argument to ``send`` must therefore contain only one message.
+
+
+Putting it all together
+*************************
+
+The complete crowdfunding contract is given below:
 
 .. code-block:: ocaml
 
@@ -520,24 +587,21 @@ The complete contract is given below:
   	    bs  <- backers;
   	    res = check_update bs _sender _amount;
   	    match res with
-  	    | None => 
-  	      msg  = {_tag : Main; _recipient : _sender; _amount : 0; 
-  		      code : already_backed_code};
-  	      msgs = one_msg msg;
-  	      send msgs
+  	    | None =>
+              e = {_eventname : "DonationFailure"; donor : _sender;
+                   amount : _amount; code : already_backed_code};
+              event e
   	    | Some bs1 =>
   	      backers := bs1; 
   	      accept; 
-  	      msg  = {_tag : Main; _recipient : _sender; _amount : 0; 
-  		      code : accepted_code};
-  	      msgs = one_msg msg;
-  	      send msgs     
+              e = {_eventname : "DonationSuccess"; donor : _sender;
+                   amount : _amount; code : accepted_code};
+              event e
   	    end  
   	  | False => 
-  	    msg  = {_tag : Main; _recipient : _sender; _amount : 0; 
-  		    code : missed_dealine_code};
-  	    msgs = one_msg msg;
-  	    send msgs
+            e = {_eventname : "DonationFailure"; donor : _sender;
+                 amount : _amount; code : missed_deadline_code};
+            event e
   	  end 
   	end
   
@@ -545,10 +609,9 @@ The complete contract is given below:
   	  is_owner = builtin eq owner _sender;
   	  match is_owner with
   	  | False => 
-  	    msg  = {_tag : Main; _recipient : _sender; _amount : 0; 
-  		    code : not_owner_code};
-  	    msgs = one_msg msg;
-  	    send msgs
+            e = {_eventname : "GetFundsFailure"; caller : _sender;
+                 amount : Uint128 0; code : not_owner_code};
+            event e
   	  | True => 
   	    blk <- & BLOCKNUMBER;
   	    in_time = blk_leq blk max_block;
@@ -559,15 +622,13 @@ The complete contract is given below:
   	    c4 = andb c1 c3;
   	    match c4 with 
   	    | False =>  
-  	      msg  = {_tag : Main; _recipient : _sender; _amount : 0; 
-  		      code : cannot_get_funds};
-  	      msgs = one_msg msg;
-  	      send msgs
+              e = {_eventname : "GetFundsFailure"; caller : _sender;
+                   amount : Uint128 0; code : cannot_get_funds};
+              event e
   	    | True => 
   	      tt = True;
   	      funded := tt;
-  	      msg  = {_tag : Main; _recipient : owner; _amount : bal; 
-  		      code : got_funds_code};
+  	      msg = {_tag : ""; _recipient : owner; _amount : bal; code : got_funds_code};
   	      msgs = one_msg msg;
   	      send msgs
   	    end
@@ -580,10 +641,9 @@ The complete contract is given below:
   	  after_deadline = builtin blt max_block blk;
   	  match after_deadline with
   	  | False =>
-  	    msg  = {_tag : Main; _recipient : _sender; _amount : 0;
-  		code : too_early_code};
-  	    msgs = one_msg msg;
-  	    send msgs
+            e = {_eventname : "ClaimBackFailure"; caller : _sender;
+                 amount : Uint128 0; code : too_early_code};
+            event e
   	  | True =>
   	    bs <- backers;
   	    bal <- _balance;
@@ -596,25 +656,22 @@ The complete contract is given below:
   	    c5 = andb c3 c4;
   	    match c5 with
   	    | False =>
-  	      msg  = {_tag : Main; _recipient : _sender; _amount : 0; 
-  		      code : cannot_reclaim_code};
-  	      msgs = one_msg msg;
-  	      send msgs
+              e = {_eventname : "ClaimBackFailure"; caller : _sender;
+                   amount : Uint128 0; code : cannot_reclaim_code};
+              event e
   	    | True =>
   	      res = builtin get bs _sender;
   	      match res with
   	      | None =>
-  		msg  = {_tag : Main; _recipient : _sender; _amount : 0; 
-  			code : cannot_reclaim_code};
-  		msgs = one_msg msg;
-  		send msgs
+                e = {_eventname : "ClaimBackFailure"; caller : _sender;
+                     amount : Uint128 0; code : cannot_reclaim_code};
+                event e
   	      | Some v =>
-  		bs1 = builtin remove bs _sender;
-  		backers := bs1;
-  		msg  = {_tag : Main; _recipient : _sender; _amount : v; 
-  			code : reclaimed_code};
-  		msgs = one_msg msg;
-  		send msgs
+                bs1 = builtin remove bs _sender;
+                backers := bs1;
+                msg = {_tag : Main; _recipient : _sender; _amount : v; code : reclaimed_code};
+                msgs = one_msg msg;
+                send msgs
   	      end
   	    end
   	  end  

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -309,7 +309,7 @@ not take a parameter.
 	Reading from a mutable variable is done via the operator ``<-``.
 
 In the ``getHello()`` transition, we will first read from a mutable
-variable, and then we construct and issue the event.
+variable, and then we construct and emit the event.
 
 
 Scilla version
@@ -370,11 +370,11 @@ construct:
       is_owner = builtin eq owner _sender;
       match is_owner with
       | False =>
-        e = {_eventname : "setHello()"; code : not_owner_code};
+        e = {_eventname : "setHello"; code : not_owner_code};
         event e
       | True =>
         welcome_msg := msg;
-        e = {_eventname : "setHello()"; code : set_hello_code};
+        e = {_eventname : "setHello"; code : set_hello_code};
         event e
       end
     end

--- a/docs/source/scilla-trial.rst
+++ b/docs/source/scilla-trial.rst
@@ -3,8 +3,7 @@
 Trying out Scilla
 =================
 
-Scilla is under active development. At this stage, there are two ways to try
-out Scilla. 
+Scilla is under active development. You can try out Scilla in the online IDE.
 
 
 Savant IDE
@@ -21,36 +20,21 @@ Users will not need to hold testnet ZIL to use Savant, instead they are given 20
 Savant serves as a staging environment, before doing automated script testing with tools
 like `Kaya (TestRPC) <https://github.com/Zilliqa/kaya>`_ and `Javascript library <https://github.com/Zilliqa/Zilliqa-JavaScript-Library>`_. To try out the Savant IDE, users need to visit `Savant IDE <https://savant-ide.zilliqa.com>`_.
 
-Blockchain IDE
-**********************
-
-The other way try out Scilla is through the `Scilla Blockchain IDE
-<https://wallet-scilla.zilliqa.com>`_. The IDE is connected to the Zilliqa
-blockchain via a `testnet wallet <https://wallet-scilla.zilliqa.com>`_ and a
-`block explorer <https://explorer-scilla.zilliqa.com>`_ and hence comes with
-(almost) all the features needed to test a Scilla contract in a real blockchain
-environment. 
-
-In order to use the Scilla Blockchain IDE, users will have to hold Testnet ZIL
-(tokens to use Zilliqa's blockchain infrastructure). Testnet ZIL tokens are
-required to pay for gas fees to deploy and run smart contracts. These tokens
-are periodically distributed for free. 
-
-To try out the Blockchain IDE, users need to go through the `Zilliqa testnet
-wallet <https://wallet-scilla.zilliqa.com>`_.
-
-
 
 Example Contracts
 ******************
 
-Both IDEs come with the following sample smart contracts written in Scilla:
+Savant IDE comes with the following sample smart contracts written in Scilla:
 
 + **HelloWorld** : It is a simple contract that allows a specified account
   denoted ``owner`` to set a welcome message. Setting the welcome message is
   done via  ``setHello (msg: String)``. The contract also provides an interface
   ``getHello()`` to allow any account to be  returned with the welcome message
   when called.
+
++ **BookStore** : A demonstration of a CRUD app. Only ``owner`` of the contract can
+  add ``members``. All ``members`` will have read/write access capability to
+  create OR update books in the inventory with `book title`, `author`, and `bookID`.
 
 + **CrowdFunding** : Crowdfunding implements a kickstarter campaign where users
   can donate funds to the contract using ``Donate()``. If the campaign is
@@ -59,7 +43,20 @@ Both IDEs come with the following sample smart contracts written in Scilla:
   ``GetFunds()``.  Else, if the campaign fails, then contributors can take back
   their donations via the transition ``ClaimBack()``.
 
-+ **ZilGame** : It is a two-player game where the goal is to find the closest
++ **OpenAuction** : A simple open auction contract where bidders can make their
+  bid using ``Bid()``, and the highest and winning bid amount goes to a
+  pre-defined account. Bidders who don't win can take back their bid using the
+  transition ``Withdraw()``. The organizer of the auction can claim the highest
+  bid by invoking the transition ``AuctionEnd()``.
+
++ **FungibleToken** : Fungible token contract that  mimics an ERC20 style fungible
+  token standard. Defacto standard for tokenised utility tokens.
+
++ **NonFungible Token** : Non fungible token contract that mimics an ERC721 style 
+  NFT token standard for unique tokenised assets. Example use case could be in-game 
+  items like CryptoKitties.
+
++ **ZilGame** : A two-player game where the goal is to find the closest
   pre-image of a given SHA256 digest (``puzzle``). More formally, given a
   digest `d`, and two values `x` and `y`, `x` is said to be a closer pre-image
   than `y` of `d` if Distance(SHA-256(x), d) < Distance(SHA-256(y), d), for
@@ -74,23 +71,6 @@ Both IDEs come with the following sample smart contracts written in Scilla:
   pre-image is declared the winner and wins a reward. The contract also
   provides a transition ``Withdraw ()`` to recover funds and send to a
   specified ``owner`` in case no player plays the game.   
-
-+ **FungibleToken** : Fungible token contract that  mimics an ERC20 style fungible
-  token standard. Defacto standard for tokenised utility tokens.
-
-+ **NonFungible Token** : Non fungible token contract that mimics an ERC721 style 
-  NFT token standard for unique tokenised assets. Example use case could be in-game 
-  items like CryptoKitties.
-
-+ **OpenAuction** : A simple open auction contract where bidders can make their
-  bid using ``Bid()``, and the highest and winning bid amount goes to a
-  pre-defined account. Bidders who don't win can take back their bid using the
-  transition ``Withdraw()``. The organizer of the auction can claim the highest
-  bid by invoking the transition ``AuctionEnd()``.
-
-+ **BookStore** : A demonstration of a CRUD app. Only ``owner`` of the contract can
-  add ``members``. All ``members`` will have read/write access capability to
-  create OR update books in the inventory with `book title`, `author`, and `bookID`.
 
 + **SchnorrTest** : A sample contract to test the generation of a Schnorr 
   public/private keypairs, signing of a ``msg`` with the private keys,


### PR DESCRIPTION
I have done some cleanup of the sections "Scilla Design Principles" and "Trying Out Scilla".

In addition, I have reworked the example contracts in the section "Scilla By Example". The HelloWorld contract should use events rather than messages, but this means that the explanation of how `send` works needed to be moved to the crowdfunding example.

I have not yet looked at the remaining sections.