### PR TITLE
Mention ADT, constructor case sensitivity and build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please preview your HTML files BEFORE submitting a pull request. Try your best t
 
 To preview:
 1. You need to have [sphinx](http://www.sphinx-doc.org/en/master/) installed. Install Sphinx by running `pip install -U Sphinx`.
+   For newer versions (>1.4.0) of Sphinx install the 'Read the Docs' theme by running `pip install -U sphinx_rtd_theme`.
 2. Run `make html` from `docs` folder and make sure that the edits are rendered correctly on the HTML file
 
 

--- a/docs/source/scilla-in-depth.rst
+++ b/docs/source/scilla-in-depth.rst
@@ -992,8 +992,9 @@ no arguments.
 
 The ADTs of a contract must have distinct names, and the set of all
 constructors of all ADTs in a contract must also have distinct
-names. However, a constructor and an ADT may have the same name, as is
-the case with the ``Pair`` type whose only constructor is also called
+names. Both the ADT and contstructor names must begin with a capital letter
+('A' - 'Z'). However, a constructor and an ADT may have the same name, as
+is the case with the ``Pair`` type whose only constructor is also called
 ``Pair``.
 
 As an example of user-defined ADTs, consider the following type


### PR DESCRIPTION
I noticed while building the project that I was lacking a dependency so I mentioned it.
ADT and constructors are mentioned to start with capital letters. 