### PR TITLE
ADT and constructor case sensitivity

### DIFF
--- a/docs/source/scilla-in-depth.rst
+++ b/docs/source/scilla-in-depth.rst
@@ -992,7 +992,7 @@ no arguments.
 
 The ADTs of a contract must have distinct names, and the set of all
 constructors of all ADTs in a contract must also have distinct
-names. Both the ADT and contstructor names must begin with a capital letter
+names. Both the ADT and constructor names must begin with a capital letter
 ('A' - 'Z'). However, a constructor and an ADT may have the same name, as
 is the case with the ``Pair`` type whose only constructor is also called
 ``Pair``.

--- a/docs/source/scilla-in-depth.rst
+++ b/docs/source/scilla-in-depth.rst
@@ -992,8 +992,9 @@ no arguments.
 
 The ADTs of a contract must have distinct names, and the set of all
 constructors of all ADTs in a contract must also have distinct
-names. However, a constructor and an ADT may have the same name, as is
-the case with the ``Pair`` type whose only constructor is also called
+names. Both the ADT and contstructor names must begin with a capital letter
+('A' - 'Z'). However, a constructor and an ADT may have the same name, as
+is the case with the ``Pair`` type whose only constructor is also called
 ``Pair``.
 
 As an example of user-defined ADTs, consider the following type


### PR DESCRIPTION
A change to mention that ADT and constructors begin with capital letters ('A' - 'Z').