### PR TITLE
Shadowing of type variables is not allowed at the moment

### DIFF
--- a/docs/source/scilla-in-depth.rst
+++ b/docs/source/scilla-in-depth.rst
@@ -378,6 +378,11 @@ Expressions
   returns the value to which expression ``expr`` evaluates. These are typically used
   to build library functions. See the implementation of fst_ for an example.
 
+  .. note::
+
+     Shadowing of type variables is not currently allowed.
+     E.g. ``tfun 'A => tfun 'A => ... `` is not a valid expression.
+
 - ``@x T``: Apply the type function ``x`` to the type ``T``. This
   specialises the type function ``x`` by instantiating the first type
   variable of ``x`` to ``T``. Type applications are typically used


### PR DESCRIPTION
Documenting fix from https://github.com/Zilliqa/scilla/pull/793