### PR TITLE
Remote reads example

### DIFF
--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -353,6 +353,46 @@ Say that the contract has been deployed at address ``0x1234567890123456789012345
    
 If a contract has immutable fields of user-defined types, then the fields must also be initialised using fully qualified names in the associated ``init.json``.
    
+Example 4: Using Address Types
+***********************************
+
+When passing an address value the type ``ByStr20`` must be used. It is
+not possible to use address types (``ByStr20 with ... end``) in
+messages.
+
+This means that for the following transition
+
+.. code-block:: ocaml
+
+   transition ListToken(
+     token_code : String,
+     new_token : ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end
+     )
+
+the ``input_message.json`` must use the type ``ByStr20`` for the
+``new_token`` parameter, e.g., as follows:
+
+.. code-block:: json
+
+    {
+      "_tag"    : "ListToken",
+      "_amount" : "0",
+      "_sender" : "0x64345678901234567890123456789012345678cd",
+      "_origin" : "0x64345678901234567890123456789012345678cd",
+      "params"  : [
+        {
+          "vname" : "token_code",
+          "type"  : "String",
+          "value" : "XYZ"
+        },
+        {
+          "vname" : "new_token",
+          "type"  : "ByStr20",
+          "value" : "0x78345678901234567890123456789012345678cd"
+        }
+      ]
+    }
+
 
 Interpreter Output
 #####################

--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -181,6 +181,55 @@ A sample ``init.json`` for this contract will look like the following:
     }
   ]
 
+Example 3: Using Address Types
+***********************************
+
+Whenever a contract has an immutable parameter of an address type, the
+type ``ByStr20`` must be used in the to initialise the parameter.
+
+For the ``SimpleExchange`` we have a single the immutable parameter,
+which has an address type:
+
+.. code-block:: ocaml
+
+   contract SimpleExchange
+   (
+     initial_admin : ByStr20 with end
+   )
+
+The JSON entry for the ``initial_admin`` parameter must use the type
+``ByStr20`` rather than the type ``ByStr20 with end``, so an example
+``init.json`` for this contract could like the following:
+
+.. code-block:: json
+
+  [
+    { 
+        "vname" : "_scilla_version",
+        "type" : "Uint32",
+        "value" : "0"
+    },
+    {
+        "vname" : "_this_address",
+        "type" : "ByStr20",
+        "value" : "0xabfeccdc9012345678901234567890f777567890"
+    },
+    {
+        "vname" : "_creation_block",
+        "type" : "BNum",
+        "value" : "1"
+    },
+    { 
+        "vname" : "initial_admin",
+        "type" : "ByStr20",
+        "value" : "0x1234567890123456789012345678901234567890"
+    }
+  ]
+
+
+
+   
+
 Input Blockchain State
 ########################
 

--- a/docs/source/scilla-by-example.rst
+++ b/docs/source/scilla-by-example.rst
@@ -1159,3 +1159,868 @@ With the helper procedures in place we are now ready to define the
                    
 Placing an Order
 ********************
+
+To place an order a user must specify the token code and the amount of
+the token he wants to sell, and the token code and amount he wants to
+buy. We invoke the ``ThrowListingStatusException`` procedure if any of
+the token codes are unlisted:
+
+.. code-block:: ocaml
+
+   transition PlaceOrder(
+     token_code_sell : String,
+     sell_amount : Uint128,
+     token_code_buy: String,
+     buy_amount : Uint128
+     )
+     (* Check that the tokens are listed *)
+     token_sell_opt <- listed_tokens[token_code_sell];
+     token_buy_opt <- listed_tokens[token_code_buy];
+     match token_sell_opt with
+     | Some token_sell =>
+       match token_buy_opt with
+       | Some token_buy => 
+         ...
+       | None =>
+         (* Unlisted token *)
+         ThrowListingStatusException token_code_buy true false
+       end
+     | None =>
+       (* Unlisted token *)
+       ThrowListingStatusException token_code_sell true false
+     end
+   end
+
+If both tokens are listed, we must first check that the user has
+supplied a sufficient allowance to the exchange. We will need a
+similar check when another user matches the order, so we define a
+helper procedure ``CheckAllowance`` to perform the check:
+
+.. code-block:: ocaml
+
+   procedure CheckAllowance(
+     token : ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end,
+     expected : Uint128
+     )
+     ...
+   end
+
+To perform the check we will need to perform a `remote read` of the
+``allowances`` field in the token contract. We are interested in the
+allowance given by the ``_sender`` to the exchange, whose address is
+given by a special immutable field ``_this_address``, so we want to
+remote read the value of ``allowances[_sender][_this_address]`` in the
+token contract.
+
+Remote reads in Scilla are performed using the operator ``<- &``, and
+we use ``.`` notation to specify the contract that we want to remote
+read from. The entire statement for the remote read is therefore as
+follows:
+
+.. code-block:: ocaml
+
+   actual_opt <-& token.allowances[_sender][_this_address];
+
+Just as when we perform a local read of a map, the result of reading
+from a remote map is an optional value. If the result is ``Some v``
+for some ``v``, then the user has provided the exchange with an
+allowance of ``v`` tokens, and if the result is ``None`` the user has
+not supplied an allowance at all. We therefore need to pattern-match
+the result to get the actual allowance:
+
+.. code-block:: ocaml
+
+   (* Find actual allowance. Use 0 if None is given *)
+   actual = match actual_opt with
+            | Some x => x
+            | None => zero
+            end;
+                
+We can now compare the actual allowance to the allowance we are
+expecting, and throw an exception if the actual allowance is
+insufficient:
+
+.. code-block:: ocaml
+
+   is_sufficient = uint128_le expected actual;
+     match is_sufficient with
+     | True => (* Nothing to do *)
+     | False =>
+       ThrowInsufficientAllowanceException token expected actual
+     end
+
+The function ``uint128_le`` is a utility function which performs a
+less-than-or-equal comparison on values of type ``Uint128``. The
+function is defined in the ``IntUtils`` part of the standard library,
+so in order to use the function we must import ``IntUtils`` into the
+contract, which is done immediately after the ``scilla_version``
+preamble, and before the contract library definitions:
+
+.. code-block:: ocaml
+
+   scilla_version 0
+   
+   import IntUtils
+   
+   library SimpleExchangeLib
+   ...                
+
+
+We also utilise a helper procedure
+``ThrowInsufficientAllowanceException`` to throw an exception if the
+allowance is insufficient, so the ``CheckAllowance`` procedure ends up
+looking as follows:
+
+.. code-block:: ocaml
+
+   procedure ThrowInsufficientAllowanceException(
+     token : ByStr20,
+     expected : Uint128,
+     actual : Uint128)
+     e = { _exception : "InsufficientAllowance";
+          token: token;
+          expected : expected;
+          actual : actual };
+     throw e
+   end
+
+   procedure CheckAllowance(
+     token : ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end,
+     expected : Uint128
+     )
+     actual_opt <-& token.allowances[_sender][_this_address];
+     (* Find actual allowance. Use 0 if None is given *)
+     actual = match actual_opt with
+              | Some x => x
+              | None => zero
+              end;
+     is_sufficient = uint128_le expected actual;
+     match is_sufficient with
+     | True => (* Nothing to do *)
+     | False =>
+       ThrowInsufficientAllowanceException token expected actual
+     end
+   end
+                
+   transition PlaceOrder(
+     token_code_sell : String,
+     sell_amount : Uint128,
+     token_code_buy: String,
+     buy_amount : Uint128
+     )
+     (* Check that the tokens are listed *)
+     token_sell_opt <- listed_tokens[token_code_sell];
+     token_buy_opt <- listed_tokens[token_code_buy];
+     match token_sell_opt with
+     | Some token_sell =>
+       match token_buy_opt with
+       | Some token_buy => 
+         (* Check that the placer has allowed sufficient funds to be accessed *)
+         CheckAllowance token_sell sell_amount;
+         ...
+       | None =>
+         (* Unlisted token *)
+         ThrowListingStatusException token_code_buy true false
+       end
+     | None =>
+       (* Unlisted token *)
+       ThrowListingStatusException token_code_sell true false
+     end
+   end
+ 
+If the user has given the exchange a sufficient allowance, the
+exchange can send a message to the token contract to perform the
+transfer of tokens from the allowance the exchange's own balance. The
+transition we need to invoke on the token contract is called
+``TransferFrom``, as opposed to ``Transfer`` which transfers funds
+from the sender's own token balance rather than from the sender's
+allowance of someone else's balance.
+
+Since the message will look much like the messages that we need when
+an order is matched, we generate the message using helper functions in
+the contract library (we will also need a new constant ``true``):
+
+.. code-block:: ocaml
+
+   library SimpleExchangeLib
+
+   let true = True
+
+   ...
+   
+   let one_msg : Message -> List Message =
+     fun (msg : Message) =>
+       let mty = Nil { Message } in
+       Cons { Message } msg mty
+
+   let mk_transfer_msg : Bool -> ByStr20 -> ByStr20 -> ByStr20 -> Uint128 -> Message =
+     fun (transfer_from : Bool) =>
+     fun (token_address : ByStr20) =>
+     fun (from : ByStr20) =>
+     fun (to : ByStr20) =>
+     fun (amount : Uint128) =>
+       let tag = match transfer_from with
+                 | True => "TransferFrom"
+                 | False => "Transfer"
+                 end
+       in
+       { _recipient : token_address;
+        _tag : tag;
+        _amount : Uint128 0;  (* No Zil are transferred, only custom tokens *)
+        from : from;
+        to : to;
+        amount : amount }
+       
+   let mk_place_order_msg : ByStr20 -> ByStr20 -> ByStr20 -> Uint128 -> List Message =
+     fun (token_address : ByStr20) =>
+     fun (from : ByStr20) =>
+     fun (to : ByStr20) =>
+     fun (amount : Uint128) =>
+       (* Construct a TransferFrom messsage to transfer from seller's allowance to exhange *)
+       let msg = mk_transfer_msg true token_address from to amount in
+       (* Create a singleton list *)
+       one_msg msg
+                   
+   contract SimpleExchange (...)
+
+   ...
+
+   transition PlaceOrder(
+     token_code_sell : String,
+     sell_amount : Uint128,
+     token_code_buy: String,
+     buy_amount : Uint128
+     )
+     (* Check that the tokens are listed *)
+     token_sell_opt <- listed_tokens[token_code_sell];
+     token_buy_opt <- listed_tokens[token_code_buy];
+     match token_sell_opt with
+     | Some token_sell =>
+       match token_buy_opt with
+       | Some token_buy => 
+         (* Check that the placer has allowed sufficient funds to be accessed *)
+         CheckAllowance token_sell sell_amount;
+         (* Transfer the sell tokens to the exchange for holding. Construct a TransferFrom message to the token contract. *)
+         msg = mk_place_order_msg token_sell _sender _this_address sell_amount;
+         (* Send message when the transition completes. *)
+         send msg;
+         ...
+       | None =>
+         (* Unlisted token *)
+         ThrowListingStatusException token_code_buy true false
+       end
+     | None =>
+       (* Unlisted token *)
+       ThrowListingStatusException token_code_sell true false
+     end
+   end
+
+
+Finally, we need to store the new order, so that users may match the
+order in the future. For this we define a new type ``Order``, which
+holds all the information needed when eventually the order is matched:
+
+.. code-block:: ocaml
+
+   (* Order placer, sell token, sell amount, buy token, buy amount *)
+   type Order =
+   | Order of ByStr20
+              (ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end)
+              Uint128
+              (ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end)
+              Uint128
+
+A value of type ``Order`` is given by the type constructor ``Order``,
+a token address and an amount of tokens to sell, and a token address
+and an amount of tokens to buy.
+
+We now need field containing a map from order numbers (of type
+``Uint128``) to ``Order``, which represents the currently active
+orders. Additionally, we will need a way to generate a unique order
+number, so we'll define a field which holds the next order number to
+use:
+
+.. code-block:: ocaml
+
+   field active_orders : Map Uint128 Order = Emp Uint128 Order
+
+   field next_order_no : Uint128 = zero
+
+To add a new order we need to generate a new order number, store the
+generated order number and the new order in the ``active_orders`` map,
+and finally increment the ``next_order_no`` field so that it is ready
+for the next order to be placed. We will put that in a helper
+procedure ``AddOrder``, and add a call to the procedure in the
+``PlaceOrder`` transition:
+
+.. code-block:: ocaml
+
+   procedure AddOrder(
+     order : Order
+     )
+     (* Get the next order number *)
+     order_no <- next_order_no;
+     (* Add the order *)
+     active_orders[order_no] := order;
+     (* Update the next_order_no field *)
+     new_order_no = builtin add order_no one;
+     next_order_no := new_order_no
+   end
+
+   transition PlaceOrder(
+     token_code_sell : String,
+     sell_amount : Uint128,
+     token_code_buy: String,
+     buy_amount : Uint128
+     )
+     (* Check that the tokens are listed *)
+     token_sell_opt <- listed_tokens[token_code_sell];
+     token_buy_opt <- listed_tokens[token_code_buy];
+     match token_sell_opt with
+     | Some token_sell =>
+       match token_buy_opt with
+       | Some token_buy => 
+         (* Check that the placer has allowed sufficient funds to be accessed *)
+         CheckAllowance token_sell sell_amount;
+         (* Transfer the sell tokens to the exchange for holding. Construct a TransferFrom message to the token contract. *)
+         msg = mk_place_order_msg token_sell _sender _this_address sell_amount;
+         (* Send message when the transition completes. *)
+         send msg;
+         (* Create order and add to list of active orders  *)
+         order = Order _sender token_sell sell_amount token_buy buy_amount;
+         AddOrder order
+       | None =>
+         (* Unlisted token *)
+         ThrowListingStatusException token_code_buy true false
+       end
+     | None =>
+       (* Unlisted token *)
+       ThrowListingStatusException token_code_sell true false
+     end
+   end
+
+``PlaceOrder`` is now complete, but there is still one thing
+missing. The `ZRC2` token standard specifies that when a
+``TransferFrom`` transition is executed, the recipient and the
+``_sender`` (known as the `initiator`) are notified in case of a
+successful transfer. These notifications are known as
+`callbacks`. Since our exchange executes a ``TransferFrom`` transition
+on the sell token, and since the exchange is the recipient of those
+tokens, we will need to specify transitions that can handle both 
+callbacks - if we don't, then the callbacks will not be recognised,
+causing the entire ``PlaceOrder`` transaction to fail.
+
+The intention behind notifying the recipient of a token transfer is to
+ensure that the recipient is capable of handling the token
+ownership. For instance, if someone were to transfer tokens to the
+``HelloWorld`` contract in the first section, the tokens would be
+locked forever, because the ``HelloWorld`` contract is incapable of
+doing anything with the tokens.
+
+Our exchange is only capable of dealing with tokens for which there is
+an active order, but in principle there is nothing stopping a user
+from transferring funds to the exchange without placing an order, so
+we need to ensure that the exchange is only involved in token
+transfers that it itself has initiated. We therefore define a
+procedure ``CheckInitiator``, which throws an exception if the
+exchange is involved in a token transfer that it itself did not
+initiate, and invoke that procedure from all callback transitions:
+
+.. code-block:: ocaml
+
+   procedure CheckInitiator(
+     initiator : ByStr20)
+     initiator_is_this = builtin eq initiator _this_address;
+     match initiator_is_this with
+     | True => (* Do nothing *)
+     | False =>
+       e = { _exception : "UnexpecedTransfer";
+            token_address : _sender;
+            initiator : initiator };
+       throw e
+     end
+   end  
+     
+   transition RecipientAcceptTransferFrom (
+     initiator : ByStr20,
+     sender : ByStr20,
+     recipient : ByStr20,
+     amount : Uint128)
+     CheckInitiator initiator
+   end  
+   
+   transition TransferFromSuccessCallBack (
+     initiator : ByStr20,
+     sender : ByStr20,
+     recipient : ByStr20,
+     amount : Uint128)
+     CheckInitiator initiator
+   end  
+                
+
+Matching an Order
+********************
+
+For the ``MatchOrder`` transition we can leverage many of the helper
+functions and procedures defined in the previous section.
+
+The user specifies an order he wishes to match. We then look up the
+order number in the ``active_orders`` map, and throw an exception if
+the order is not found:
+
+.. code-block:: ocaml
+
+   transition MatchOrder(
+     order_id : Uint128)
+     order <- active_orders[order_id];
+     match order with
+     | Some (Order order_placer sell_token sell_amount buy_token buy_amount) =>
+       ...
+     | None =>
+       e = { _exception : "UnknownOrder";
+            order_id : order_id };
+       throw e
+     end
+   end
+                
+In order to match the order, the matcher has to provide sufficient
+allowance of the buy token. This is checked by the ``CheckAllowance``
+procedure we defined earlier, so we simply reuse that procedure here:
+
+.. code-block:: ocaml
+
+   transition MatchOrder(
+     order_id : Uint128)
+     order <- active_orders[order_id];
+     match order with
+     | Some (Order order_placer sell_token sell_amount buy_token buy_amount) =>
+       (* Check that the placer has allowed sufficient funds to be accessed *)
+       CheckAllowance buy_token buy_amount;
+       ...
+     | None =>
+       e = { _exception : "UnknownOrder";
+            order_id : order_id };
+       throw e
+     end
+   end
+
+We now need to generate two transfer messages: One message is a
+``TransferFrom`` message on the buy token, transferring the matcher's
+allowance to the user who placed the order, and the other message is a
+``Transfer`` message on the sell token, transferring the tokens held
+by the exchange to the order matcher. Once again, we define helper
+functions to generate the messages:
+
+.. code-block:: ocaml
+
+   library SimpleExchangeLib
+
+   ...
+   
+   let two_msgs : Message -> Message -> List Message =
+     fun (msg1 : Message) =>
+     fun (msg2 : Message) =>
+       let first = one_msg msg1 in
+       Cons { Message } msg2 first
+   
+   let mk_make_order_msgs : ByStr20 -> Uint128 -> ByStr20 -> Uint128 ->
+                             ByStr20 -> ByStr20 -> ByStr20 -> List Message =
+     fun (token_sell_address : ByStr20) =>
+     fun (sell_amount : Uint128) =>
+     fun (token_buy_address : ByStr20) =>
+     fun (buy_amount : Uint128) =>
+     fun (this_address : ByStr20) =>
+     fun (order_placer : ByStr20) =>
+     fun (order_maker : ByStr20) =>
+       (* Construct a Transfer messsage to transfer from exchange to maker *)
+       let sell_msg = mk_transfer_msg false token_sell_address this_address order_maker sell_amount in
+       (* Construct a TransferFrom messsage to transfer from maker to placer *)
+       let buy_msg = mk_transfer_msg true token_buy_address order_maker order_placer buy_amount in
+       (* Create a singleton list *)
+       two_msgs sell_msg buy_msg
+
+  ...
+
+  contract SimpleExchange (...)
+
+  ...
+  
+  transition MatchOrder(
+     order_id : Uint128)
+     order <- active_orders[order_id];
+     match order with
+     | Some (Order order_placer sell_token sell_amount buy_token buy_amount) =>
+       (* Check that the placer has allowed sufficient funds to be accessed *)
+       CheckAllowance buy_token buy_amount;
+       (* Create the two transfer messages and send them *)
+       msgs = mk_make_order_msgs sell_token sell_amount buy_token buy_amount _this_address order_placer _sender;
+       send msgs;
+       ...
+     | None =>
+       e = { _exception : "UnknownOrder";
+            order_id : order_id };
+       throw e
+     end
+   end
+
+Since the order has now been matched, it should no longer be listed as
+an active order, so we delete the entry in ``active_orders``:
+
+.. code-block:: ocaml
+
+   transition MatchOrder(
+     order_id : Uint128)
+     order <- active_orders[order_id];
+     match order with
+     | Some (Order order_placer sell_token sell_amount buy_token buy_amount) =>
+       (* Check that the placer has allowed sufficient funds to be accessed *)
+       CheckAllowance buy_token buy_amount;
+       (* Create the two transfer messages and send them *)
+       msgs = mk_make_order_msgs sell_token sell_amount buy_token buy_amount _this_address order_placer _sender;
+       send msgs;
+       (* Order has now been matched, so remove it *)
+       delete active_orders[order_id]
+     | None =>
+       e = { _exception : "UnknownOrder";
+            order_id : order_id };
+       throw e
+     end
+   end
+
+This concludes the ``MatchOrder`` transition, but we need to define
+one additional callback transition. When placing an order we executed
+a ``TransferFrom`` transition, but now we also execute a ``Transfer``
+transition, which gives rise to a different callback:
+
+.. code-block:: ocaml
+
+   transition TransferSuccessCallBack (
+     initiator : ByStr20,
+     sender : ByStr20,
+     recipient : ByStr20,
+     amount : Uint128)
+     (* The exchange only accepts transfers that it itself has initiated.  *)
+     CheckInitiator initiator
+   end
+
+Note that we do not need to specify a transition handling the receipt
+of tokens from a ``Transfer`` transition. The exchange never executes
+a ``Transfer`` with itself as the recipient, so if a user decides to
+do so, then the recipient callback will fail by there not being such a
+transition on the exchange.
+
+Putting it All Together
+*************************
+
+We now have everything in place to specify the entire contract:
+
+.. code-block:: ocaml
+
+   scilla_version 0
+   
+   import IntUtils
+   
+   library SimpleExchangeLib
+   
+   (* Order placer, sell token, sell amount, buy token, buy amount *)
+   type Order =
+   | Order of ByStr20
+              (ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end)
+              Uint128
+              (ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end)
+              Uint128
+   
+   (* Helper values and functions *)
+   let true = True
+   let false = False
+   
+   let zero = Uint128 0
+   let one = Uint128 1
+   
+   let one_msg : Message -> List Message =
+     fun (msg : Message) =>
+       let mty = Nil { Message } in
+       Cons { Message } msg mty
+   
+   let two_msgs : Message -> Message -> List Message =
+     fun (msg1 : Message) =>
+     fun (msg2 : Message) =>
+       let first = one_msg msg1 in
+       Cons { Message } msg2 first
+   
+   let mk_transfer_msg : Bool -> ByStr20 -> ByStr20 -> ByStr20 -> Uint128 -> Message =
+     fun (transfer_from : Bool) =>
+     fun (token_address : ByStr20) =>
+     fun (from : ByStr20) =>
+     fun (to : ByStr20) =>
+     fun (amount : Uint128) =>
+       let tag = match transfer_from with
+                 | True => "TransferFrom"
+                 | False => "Transfer"
+                 end
+       in
+       { _recipient : token_address;
+        _tag : tag;
+        _amount : Uint128 0;  (* No Zil are transferred, only custom tokens *)
+        from : from;
+        to : to;
+        amount : amount }
+       
+   let mk_place_order_msg : ByStr20 -> ByStr20 -> ByStr20 -> Uint128 -> List Message =
+     fun (token_address : ByStr20) =>
+     fun (from : ByStr20) =>
+     fun (to : ByStr20) =>
+     fun (amount : Uint128) =>
+       (* Construct a TransferFrom messsage to transfer from seller's allowance to exhange *)
+       let msg = mk_transfer_msg true token_address from to amount in
+       (* Create a singleton list *)
+       one_msg msg
+   
+   let mk_make_order_msgs : ByStr20 -> Uint128 -> ByStr20 -> Uint128 ->
+                             ByStr20 -> ByStr20 -> ByStr20 -> List Message =
+     fun (token_sell_address : ByStr20) =>
+     fun (sell_amount : Uint128) =>
+     fun (token_buy_address : ByStr20) =>
+     fun (buy_amount : Uint128) =>
+     fun (this_address : ByStr20) =>
+     fun (order_placer : ByStr20) =>
+     fun (order_maker : ByStr20) =>
+       (* Construct a Transfer messsage to transfer from exchange to maker *)
+       let sell_msg = mk_transfer_msg false token_sell_address this_address order_maker sell_amount in
+       (* Construct a TransferFrom messsage to transfer from maker to placer *)
+       let buy_msg = mk_transfer_msg true token_buy_address order_maker order_placer buy_amount in
+       (* Create a singleton list *)
+       two_msgs sell_msg buy_msg
+   
+   
+   contract SimpleExchange
+   (
+     (* Ensure that the initial admin is an address that is in use *)
+     initial_admin : ByStr20 with end
+   )
+   
+   (* Active admin. *)
+   field admin : ByStr20 with end = initial_admin
+   
+   (* Tokens listed on the exchange. *)
+   (* We identify the token by its exchange code, and map it to the address     *)
+   (* of the contract implementing the token. The contract at that address must *)
+   (* contain an allowances field that we can remote read.                      *)
+   field listed_tokens :
+     Map String (ByStr20 with contract
+                                field allowances : Map ByStr20 (Map ByStr20 Uint128)
+                         end)
+     = Emp String (ByStr20 with contract
+                                  field allowances : Map ByStr20 (Map ByStr20 Uint128)
+                           end)
+   
+   (* Active orders, identified by the order number *)
+   field active_orders : Map Uint128 Order = Emp Uint128 Order
+   
+   (* The order number to use when the next order is placed *)
+   field next_order_no : Uint128 = zero
+   
+   procedure ThrowListingStatusException(
+     token_code : String,
+     expected_status : Bool,
+     actual_status : Bool)
+     e = { _exception : "UnexpectedListingStatus";
+          token_code: token_code;
+          expected : expected_status;
+          actual : actual_status };
+     throw e
+   end
+   
+   procedure ThrowInsufficientAllowanceException(
+     token : ByStr20,
+     expected : Uint128,
+     actual : Uint128)
+     e = { _exception : "InsufficientAllowance";
+          token: token;
+          expected : expected;
+          actual : actual };
+     throw e
+   end
+   
+   (* Check that _sender is the active admin.          *)
+   (* If not, throw an error and abort the transaction *)
+   procedure CheckSenderIsAdmin()
+     current_admin <- admin;
+     is_admin = builtin eq _sender current_admin;
+     match is_admin with
+     | True =>  (* Nothing to do *)
+     | False =>
+       (* Construct an exception object and throw it *)
+       e = { _exception : "SenderIsNotAdmin" };
+       throw e
+     end
+   end
+   
+   (* Change the active admin *)
+   transition SetAdmin(
+     new_admin : ByStr20 with end
+     )
+     (* Only the former admin may appoint a new admin *)
+     CheckSenderIsAdmin;
+     admin := new_admin
+   end
+   
+   (* Check that a given token code is not already listed. If it is, throw an error. *)
+   procedure CheckIsTokenUnlisted(
+     token_code : String
+     )
+     (* Is the token code listed? *)
+     token_code_is_listed <- exists listed_tokens[token_code];
+     match token_code_is_listed with
+     | True =>
+       (* Incorrect listing status *)
+       ThrowListingStatusException token_code false token_code_is_listed
+     | False => (* Nothing to do *)
+     end
+   end
+   
+   (* List a new token on the exchange. Only the admin may list new tokens.  *)
+   (* If a token code is already in use, raise an error                      *)
+   transition ListToken(
+     token_code : String,
+     new_token : ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end
+     )
+     (* Only the admin may list new tokens.  *)
+     CheckSenderIsAdmin;
+     (* Only new token codes are allowed.  *)
+     CheckIsTokenUnlisted token_code;
+     (* Everything is ok. The token can be listed *)
+     listed_tokens[token_code] := new_token
+   end
+   
+   (* Check that the sender has allowed access to sufficient funds *)
+   procedure CheckAllowance(
+     token : ByStr20 with contract field allowances : Map ByStr20 (Map ByStr20 Uint128) end,
+     expected : Uint128
+     )
+     actual_opt <-& token.allowances[_sender][_this_address];
+     (* Find actual allowance. Use 0 if None is given *)
+     actual = match actual_opt with
+              | Some x => x
+              | None => zero
+              end;
+     is_sufficient = uint128_le expected actual;
+     match is_sufficient with
+     | True => (* Nothing to do *)
+     | False =>
+       ThrowInsufficientAllowanceException token expected actual
+     end
+   end
+   
+   procedure AddOrder(
+     order : Order
+     )
+     (* Get the next order number *)
+     order_no <- next_order_no;
+     (* Add the order *)
+     active_orders[order_no] := order;
+     (* Update the next_order_no field *)
+     new_order_no = builtin add order_no one;
+     next_order_no := new_order_no
+   end
+   
+   (* Place an order on the exchange *)
+   transition PlaceOrder(
+     token_code_sell : String,
+     sell_amount : Uint128,
+     token_code_buy: String,
+     buy_amount : Uint128
+     )
+     (* Check that the tokens are listed *)
+     token_sell_opt <- listed_tokens[token_code_sell];
+     token_buy_opt <- listed_tokens[token_code_buy];
+     match token_sell_opt with
+     | Some token_sell =>
+       match token_buy_opt with
+       | Some token_buy => 
+         (* Check that the placer has allowed sufficient funds to be accessed *)
+         CheckAllowance token_sell sell_amount;
+         (* Transfer the sell tokens to the exchange for holding. Construct a TransferFrom message to the token contract. *)
+         msg = mk_place_order_msg token_sell _sender _this_address sell_amount;
+         (* Send message when the transition completes. *)
+         send msg;
+         (* Create order and add to list of active orders  *)
+         order = Order _sender token_sell sell_amount token_buy buy_amount;
+         AddOrder order
+       | None =>
+         (* Unlisted token *)
+         ThrowListingStatusException token_code_buy true false
+       end
+     | None =>
+       (* Unlisted token *)
+       ThrowListingStatusException token_code_sell true false
+     end
+   end
+   
+   transition MatchOrder(
+     order_id : Uint128)
+     order <- active_orders[order_id];
+     match order with
+     | Some (Order order_placer sell_token sell_amount buy_token buy_amount) =>
+       (* Check that the placer has allowed sufficient funds to be accessed *)
+       CheckAllowance buy_token buy_amount;
+       (* Create the two transfer messages and send them *)
+       msgs = mk_make_order_msgs sell_token sell_amount buy_token buy_amount _this_address order_placer _sender;
+       send msgs;
+       (* Order has now been matched, so remove it *)
+       delete active_orders[order_id]
+     | None =>
+       e = { _exception : "UnknownOrder";
+            order_id : order_id };
+       throw e
+     end
+   end
+   
+   procedure CheckInitiator(
+     initiator : ByStr20)
+     initiator_is_this = builtin eq initiator _this_address;
+     match initiator_is_this with
+     | True => (* Do nothing *)
+     | False =>
+       e = { _exception : "UnexpecedTransfer";
+            token_address : _sender;
+            initiator : initiator };
+       throw e
+     end
+   end  
+     
+   transition RecipientAcceptTransferFrom (
+     initiator : ByStr20,
+     sender : ByStr20,
+     recipient : ByStr20,
+     amount : Uint128)
+     (* The exchange only accepts transfers that it itself has initiated.  *)
+     CheckInitiator initiator
+   end  
+   
+   transition TransferFromSuccessCallBack (
+     initiator : ByStr20,
+     sender : ByStr20,
+     recipient : ByStr20,
+     amount : Uint128)
+     (* The exchange only accepts transfers that it itself has initiated.  *)
+     CheckInitiator initiator
+   end  
+   
+   transition TransferSuccessCallBack (
+     initiator : ByStr20,
+     sender : ByStr20,
+     recipient : ByStr20,
+     amount : Uint128)
+     (* The exchange only accepts transfers that it itself has initiated.  *)
+     CheckInitiator initiator
+   end  
+   
+                   
+As mentioned in the introduction we have kept the exchange simplistic
+in order to keep the focus on Scilla features. We encourage the reader
+to add additional features such as unlisting of tokens, cancellation
+of orders, orders with expiry time, prioritising orders so that the
+order matcher gets the best deal possible, partial matching of orders,
+securing the exchange against abuse, fees for trading on the exchange,
+etc..


### PR DESCRIPTION
A rather elaborate example using remote reads.

I have also added an example in the Interpreter Interface section on how (not) to use address types in message jsons.