### PR TITLE
Fix typo in scilla-in-depth.rst

### DIFF
--- a/docs/source/scilla-in-depth.rst
+++ b/docs/source/scilla-in-depth.rst
@@ -201,7 +201,7 @@ fields get modified.
    type ``Uint128``, which is initialised to 0 when the contract is
    deployed. The ``_balance`` field keeps the amount of funds held by
    the contract, measured in QA (1 ZIL = 1,000,000,000,000 QA).  This
-   field can be freely read within the implementation, but can only
+   field can be freely read within the implementation, but can only be
    modified by explicitly transferring funds to other accounts (using
    ``send``), or by accepting money from incoming messages (using
    ``accept``).


### PR DESCRIPTION
Noticed a typo while reading through https://scilla.readthedocs.io/en/latest/scilla-in-depth.html?highlight=event#communication

![image](https://user-images.githubusercontent.com/17170991/134656136-6deae6cd-0f2a-4b78-b94a-fe06a2a37728.png)
